### PR TITLE
Add grunt-svgstore

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -11,12 +11,32 @@ module.exports = function(grunt) {
           dest: "fallbacks/"
         }]
       }
+    },
+
+    svgstore: {
+      options: {
+        prefix : 'icon-', // This will prefix each ID
+        svg: {
+          viewBox : '0 0 50 50',
+          style: "display: none;"
+        },
+        cleanup: true,
+        formatting : {
+          indent_size : 2
+        }
+      },
+      default : {
+        files: {
+          'svgdefs.svg': ['svg/*.svg'],
+        }
+      }
     }
 
   });
 
   grunt.loadNpmTasks("grunt-grunticon");
+  grunt.loadNpmTasks("grunt-svgstore");
 
-  grunt.registerTask("default", ["grunticon"]);
+  grunt.registerTask("default", ["svgstore","grunticon"]);
 
 };

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -20,7 +20,7 @@ module.exports = function(grunt) {
           viewBox : '0 0 50 50',
           style: "display: none;"
         },
-        cleanup: true,
+        cleanup: ['fill','stroke'],
         formatting : {
           indent_size : 2
         }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "devDependencies": {
     "grunt": "^0.4.5",
-    "grunt-grunticon": "^2.1.2"
+    "grunt-grunticon": "^2.1.2",
+    "grunt-svgstore": "^0.5.0"
   }
 }


### PR DESCRIPTION
Hi :) I forked this to start a little svg/grunt starter repo on my end and felt it may be a good idea to include grunt-svgstore to your repo as well. This would kind of make it a standalone fully functional solution that creates the SVG defs/sprite and handles Grunticon.

Might be overkill for your demo but thought I'd share. Tnx again.
